### PR TITLE
BugFix - conflito no retorno de status do pedido

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,9 +17,9 @@ module.exports = {
     //abandoned: 'v2/transactions' TODO: use?
     directPayment: "v2/transactions",
     code: "v2/transactions",
-    refund: "v2/transactions/refunds/",
-    cancel: "v2/transactions/cancels/",
-    notification: "v3/transactions/notifications/"
+    refund: "v2/transactions/refunds",
+    cancel: "v2/transactions/cancels",
+    notification: "v3/transactions/notifications"
   },
   split: {
     transaction: "transactions"


### PR DESCRIPTION
No arquivo config.js , na parte de transaction, em 3 urls existia uma "/" no final das urls, o que ficava duplicado quando o pagseguro enviava o retorno de atualizacao dos pedidos ou para cancelar o pedido, por isso retornava um erro 404, pois a rota nao existia, 

https://pagseguro.uol.com.br/v3/transactions/notifications//... restante da url